### PR TITLE
ADHOC fix service-definition: repair compatibility

### DIFF
--- a/tasks/binary.yml
+++ b/tasks/binary.yml
@@ -21,7 +21,7 @@
   when: bin.stat.exists == False or
         bin.stat.checksum != mysqld_exporter_checksum_binary
 
-- name: "Move node-exporter to the /usr/local/bin/node-exporter"
+- name: "Move mysqld-exporter to the /usr/local/bin/mysqld_exporter"
   copy:
     remote_src: true
     src: "/tmp/mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ mysqld_exporter_arch }}/mysqld_exporter"

--- a/templates/etc/systemd/system/mysqld_exporter.service.j2
+++ b/templates/etc/systemd/system/mysqld_exporter.service.j2
@@ -7,8 +7,8 @@ Documentation=https://github.com/sitewards/ansible-role-mysqld-exporter
 
 # Start the service, bound to localhost. It will be exposed by another service, such as NGINX or stunnel.
 ExecStart=/usr/local/bin/mysqld_exporter \
-    -config.my-cnf="/etc/node_exporter/.my.cnf" \
-    -web.listen-address="127.0.0.1:9104"
+    --config.my-cnf="/etc/node_exporter/.my.cnf" \
+    --web.listen-address="127.0.0.1:9104"
 
 [Install]
 


### PR DESCRIPTION
repairing small typo and compatibility issue that caused daemon to die.

https://github.com/prometheus/mysqld_exporter/releases

    BREAKING CHANGES:
    Flags now use the Kingpin library, and require double-dashes. #222